### PR TITLE
fix: Anchor version greps in Sparkle CI template

### DIFF
--- a/skills/macos-app-scaffold-enhance/SKILL.md
+++ b/skills/macos-app-scaffold-enhance/SKILL.md
@@ -164,8 +164,17 @@ For Sparkle:
     rm -f "$RUNNER_TEMP/sparkle_eddsa.key"
 
     ED_SIGNATURE=$(echo "$SIGN_OUTPUT" | sed -n 's/.*sparkle:edSignature="\([^"]*\)".*/\1/p')
-    VERSION=$(grep MARKETING_VERSION project.yml | head -1 | awk -F'"' '{print $2}')
-    BUILD=$(grep CURRENT_PROJECT_VERSION project.yml | head -1 | awk -F'"' '{print $2}')
+    # Anchor the grep so it matches the SETTING line (MARKETING_VERSION: "1.2.3")
+    # and skips reference lines like CFBundleShortVersionString: $(MARKETING_VERSION).
+    # Without the anchor, `head -1` may pick a reference line that has no quotes
+    # and `awk -F'"' '{print $2}'` returns empty — silently producing an appcast
+    # with empty <sparkle:version>/<sparkle:shortVersionString>.
+    VERSION=$(grep -E '^\s*MARKETING_VERSION: ' project.yml | head -1 | awk -F'"' '{print $2}')
+    BUILD=$(grep -E '^\s*CURRENT_PROJECT_VERSION: ' project.yml | head -1 | awk -F'"' '{print $2}')
+    if [ -z "$VERSION" ] || [ -z "$BUILD" ]; then
+      echo "ERROR: failed to parse MARKETING_VERSION or CURRENT_PROJECT_VERSION from project.yml"
+      exit 1
+    fi
     FILE_LENGTH=$(stat -f%z "$APP_NAME.dmg")
     TAG="${GITHUB_REF_NAME}"
     DOWNLOAD_URL="https://github.com/${GITHUB_REPOSITORY}/releases/download/${TAG}/${APP_NAME}.dmg"


### PR DESCRIPTION
## Summary

In the auto-update / Sparkle section of `macos-app-scaffold-enhance/SKILL.md`, the appcast-generation step parses `MARKETING_VERSION` and `CURRENT_PROJECT_VERSION` out of `project.yml` with un-anchored greps:

```bash
VERSION=$(grep MARKETING_VERSION project.yml | head -1 | awk -F'"' '{print $2}')
BUILD=$(grep CURRENT_PROJECT_VERSION project.yml | head -1 | awk -F'"' '{print $2}')
```

A standard `project.yml` contains both the YAML setting line and one or more reference lines:

```yaml
        CFBundleShortVersionString: $(MARKETING_VERSION)   # reference, no quotes
        CFBundleVersion: $(CURRENT_PROJECT_VERSION)        # reference, no quotes
        ...
        MARKETING_VERSION: "1.4.7"                         # actual setting
        CURRENT_PROJECT_VERSION: "46"                      # actual setting
```

The reference lines come first in `project.yml` for menubar / app-style apps, so `head -1` picks them. Those lines have no double quotes → `awk -F'"' '{print $2}'` returns empty → the generated `appcast.xml` silently ships with empty `<sparkle:version>` and `<sparkle:shortVersionString>`. Sparkle's version comparison then misbehaves and clients never see the update as newer.

## Fix

Anchor the patterns so they only match the YAML setting line, and exit non-zero if either parse produces an empty string:

```bash
VERSION=$(grep -E '^\s*MARKETING_VERSION: ' project.yml | head -1 | awk -F'"' '{print $2}')
BUILD=$(grep -E '^\s*CURRENT_PROJECT_VERSION: ' project.yml | head -1 | awk -F'"' '{print $2}')
if [ -z "$VERSION" ] || [ -z "$BUILD" ]; then
  echo "ERROR: failed to parse MARKETING_VERSION or CURRENT_PROJECT_VERSION from project.yml"
  exit 1
fi
```

## Context

Hit this while integrating Sparkle into [CCSwitcher](https://github.com/XueshiQiao/CCSwitcher). The first appcast that built green (v1.5.2) had `<sparkle:version></sparkle:version>` and we only caught it visually post-publish. v1.5.3 fixed it after anchoring the grep.

## Test plan

- [x] Locally verified `grep -E '^\s*MARKETING_VERSION: ' project.yml | head -1 | awk -F'"' '{print $2}'` returns the right value on a real project.yml that has both a setting line and `$(MARKETING_VERSION)` references.
- [x] CI build of CCSwitcher v1.5.3 produced an appcast with non-empty version fields and Sparkle now serves updates correctly.